### PR TITLE
:config should be :options

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
   </script>
   <main>
     <h2>MathLive with Vue.js</h2>
-    <mathlive-mathfield id="mf" ref="mathfield" :config="{smartFence:false}" @focus="ping"
+    <mathlive-mathfield id="mf" ref="mathfield" :options="{smartFence:false, virtualKeyboardMode:'onfocus'}" @focus="ping"
       :on-keystroke="displayKeystroke" v-model="formula">f(x)=</mathlive-mathfield>
     <div><label>Keystroke:&nbsp;</label><span>{{keystroke}}</span></div>
     <div class="output">LaTeX: {{formula}}</div>


### PR DESCRIPTION
`:config` do nothing and it should be replaced by `:options`.
Also the virtual keyboard don't work without `virtualKeyboardMode:'onfocus'`.
So it should be: `:options="{smartFence:false, virtualKeyboardMode:'onfocus'}"`
or at least  `:options="{smartFence:false}"` if you don't want virtual keyboard to work.